### PR TITLE
Allow using envvars for template substitutions

### DIFF
--- a/examples/using_envvars.yaml
+++ b/examples/using_envvars.yaml
@@ -1,0 +1,7 @@
+---
+headers:
+  Content-Type: application/json
+  Authorization: "Token {env[TOKEN]}"
+method: GET
+host: http://localhost:8002
+path: /api/automation-hub/content/community/v3/collections/

--- a/hermes/main.py
+++ b/hermes/main.py
@@ -9,6 +9,10 @@ from pathlib import Path
 
 class Config:
 
+    _context = {
+        "env": os.environ,
+    }
+
     def __init__(self, config, templates):
         self._config = config
         self._cli_templates = self.load_templates(templates)
@@ -53,7 +57,7 @@ class Config:
         return self._format_config(' '.join(flag_vals), 'curl_flags')
 
     def _format_config(self, value, key):
-        merged_template = {**self._config_templates, **self._cli_templates}
+        merged_template = {**self._context, **self._config_templates, **self._cli_templates}
 
         try:
             return value.format(**merged_template)


### PR DESCRIPTION
```yaml
---
headers:
  Content-Type: application/json
  Authorization: "Token {env[TOKEN]}"
method: GET
host: http://localhost:8002
path: /api/automation-hub/content/community/v3/collections/
```
then
```bash
❯ export TOKEN=MyAwesomeToken 
❯ hermes -p using_envvars.yaml 
{}
curl \
  -X GET \
  -H 'Content-Type: application/json' -H 'Authorization: Token MyAwesomeToken' \
  http://localhost:8002/api/automation-hub/content/community/v3/collections/
```